### PR TITLE
Fix player hitbox blocking wiring tools raycast detection

### DIFF
--- a/Source/FicsitWiremod/Private/Equipment/WiremodBaseTool.cpp
+++ b/Source/FicsitWiremod/Private/Equipment/WiremodBaseTool.cpp
@@ -16,14 +16,18 @@ void AWiremodBaseTool::SetOutline(AActor* Object, EOutlineColor Color)
 AActor* AWiremodBaseTool::GetTargetLookAt(double TraceDistance, TEnumAsByte<ETraceTypeQuery> Channel, FVector& Location,
 	bool& Success)
 {
-	constexpr double RaycastStartOffset = 200; //arbitrary, but works well.
 	auto camera = UGameplayStatics::GetPlayerCameraManager(this, 0);
 
-	FVector Start = camera->GetCameraLocation() + camera->GetActorForwardVector() * RaycastStartOffset;
-	FVector End = camera->GetCameraLocation() + camera->GetActorForwardVector() * (TraceDistance + RaycastStartOffset);
+	FVector Start = camera->GetCameraLocation();
+	FVector End = camera->GetCameraLocation() + camera->GetActorForwardVector() * TraceDistance;
 	FHitResult Result;
 
-	Success = UKismetSystemLibrary::LineTraceSingle(this, Start, End, Channel, false, TArray<AActor*>(), EDrawDebugTrace::None, Result, true);
+	TArray<AActor*> RaycastIgnoredActors =
+	{
+		GetInstigatorCharacter() //Ignoring player character holding the tool (self-collission)
+	};
+
+	Success = UKismetSystemLibrary::LineTraceSingle(this, Start, End, Channel, false, RaycastIgnoredActors, EDrawDebugTrace::None, Result, true);
 	return UWiremodUtils::GetActualHitTarget(Result, Location);
 }
 

--- a/Source/FicsitWiremod/Private/Equipment/WiremodBaseTool.cpp
+++ b/Source/FicsitWiremod/Private/Equipment/WiremodBaseTool.cpp
@@ -16,10 +16,11 @@ void AWiremodBaseTool::SetOutline(AActor* Object, EOutlineColor Color)
 AActor* AWiremodBaseTool::GetTargetLookAt(double TraceDistance, TEnumAsByte<ETraceTypeQuery> Channel, FVector& Location,
 	bool& Success)
 {
+	constexpr double RaycastStartOffset = 200; //arbitrary, but works well.
 	auto camera = UGameplayStatics::GetPlayerCameraManager(this, 0);
 
-	FVector Start = camera->GetCameraLocation();
-	FVector End = camera->GetCameraLocation() + camera->GetActorForwardVector() * TraceDistance;
+	FVector Start = camera->GetCameraLocation() + camera->GetActorForwardVector() * RaycastStartOffset;
+	FVector End = camera->GetCameraLocation() + camera->GetActorForwardVector() * (TraceDistance + RaycastStartOffset);
 	FHitResult Result;
 
 	Success = UKismetSystemLibrary::LineTraceSingle(this, Start, End, Channel, false, TArray<AActor*>(), EDrawDebugTrace::None, Result, true);


### PR DESCRIPTION
Apply a 200-unit offset to raycast tests in the AWiremodBaseTool::GetTargetLookAt function

When moving around for long enough (potentially with a hypertube), the wiring tools will eventually have trouble detecting other entities besides the player entity. This fixes that by applying an (arbitrarily chosen) offset to the GetTargetLookAt raycast of 200 units. The raycast will skip the player bounding box, and correctly detect the intended look-at target

Another helpful user encountered the bug, and wrote a full description (with a video) showing the issue [on Discord](https://discord.com/channels/697414436322803763/1404985785203294389)